### PR TITLE
Modernize configs: fix broken syntax, outdated paths, expand thin configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,45 @@
-These dotfiles are managed using dotbot, because I'm too lazy to maintain a makefile and it's approachable enough that I can forget how to use it
-[https://github.com/anishathalye/dotbot]()
+# dotfiles
 
-### How To Use
-`./install` runs the whole thing!
+Personal dotfiles managed with [dotbot](https://github.com/anishathalye/dotbot).
 
-`./install.conf.yaml` has all the configuration for what gets linked where
+## What's Included
+
+| Tool | File | Notes |
+|------|------|-------|
+| Zsh | `zshrc` | oh-my-zsh, agnoster theme, git plugin |
+| Shell env | `profile` | `$EDITOR`, `servedir` alias, Conda PATH |
+| Git | `gitconfig` | User info, colors, aliases (`hist`, `s`, `ph`, `c`) |
+| Git ignore | `gitignore` | Global ignores (macOS, editors, Python, Node) |
+| Vim | `vimrc` | Pathogen, line numbers, 2-space indent, syntax highlighting |
+| Tmux | `tmux.conf` | Mouse, vi mode, Ctrl-a prefix, pane splits, status bar |
+| EditorConfig | `editorconfig` | Cross-editor indent/whitespace consistency |
+| ESLint | `eslintrc` | React + Babel, ES2017 |
+
+## Prerequisites
+
+- **Zsh** — the primary shell
+- **oh-my-zsh** — managed as a git submodule (`oh-my-zsh/`)
+- **Powerline fonts** — required by the agnoster theme ([install](https://github.com/powerline/fonts))
+- **Git** — for cloning and submodule initialization
+
+### Optional
+
+- **Conda (miniconda3)** — if installed at `~/miniconda3`, it's added to `$PATH` automatically
+- **Google Cloud SDK** — if installed at `~/dev/lib/google-cloud-sdk`, `gcloud` PATH and completions are sourced automatically
+
+## Installation
+
+```sh
+git clone --recursive https://github.com/hidinginabunker/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+./install
+```
+
+If you cloned without `--recursive`, initialize submodules first:
+
+```sh
+git submodule update --init --recursive
+./install
+```
+
+The `install` script uses dotbot to create symlinks from your home directory to this repo. See `install.conf.yaml` for the full mapping.

--- a/eslintrc
+++ b/eslintrc
@@ -3,7 +3,7 @@
   "env": {
     "browser": true,
     "node": true,
-    "es6": true,
+    "es6": true
   },
   "rules": {
     "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": false }],

--- a/profile
+++ b/profile
@@ -4,6 +4,9 @@
 export EDITOR=vim
 
 # Aliases
-alias servedir="python -m SimpleHTTPServer"
+alias servedir="python3 -m http.server"
 
-export PATH=$PATH:$HOME/Library/Python/2.7/bin:/Users/gherrera/miniconda3/bin:
+# Conda
+if [ -d "$HOME/miniconda3/bin" ]; then
+  export PATH=$PATH:$HOME/miniconda3/bin
+fi

--- a/tmux.conf
+++ b/tmux.conf
@@ -1,3 +1,28 @@
 # Enable Mouse Support
 set -g mouse on
+
+# Vi key bindings in copy mode
 set-window-option -g mode-keys vi
+
+# Use Ctrl-a as prefix (more ergonomic), keep Ctrl-b as secondary
+set -g prefix C-a
+bind C-a send-prefix
+bind C-b send-prefix
+
+# Reload config with prefix-r
+bind r source-file ~/.tmux.conf \; display "Config reloaded"
+
+# Intuitive pane splitting: | for horizontal, - for vertical
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+
+# Open new windows in current directory
+bind c new-window -c "#{pane_current_path}"
+
+# 256-color support
+set -g default-terminal "screen-256color"
+
+# Status bar
+set -g status-left "[#S] "
+set -g status-right "%Y-%m-%d %H:%M"
+set -g status-right-length 30

--- a/zshrc
+++ b/zshrc
@@ -94,7 +94,7 @@ test -e "${HOME}/.profile" && source "${HOME}/.profile"
 test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"
 
 # The next line updates PATH for the Google Cloud SDK.
-if [ -f '/Users/gherrera/dev/lib/google-cloud-sdk/path.zsh.inc' ]; then source '/Users/gherrera/dev/lib/google-cloud-sdk/path.zsh.inc'; fi
+if [ -f "$HOME/dev/lib/google-cloud-sdk/path.zsh.inc" ]; then source "$HOME/dev/lib/google-cloud-sdk/path.zsh.inc"; fi
 
 # The next line enables shell command completion for gcloud.
-if [ -f '/Users/gherrera/dev/lib/google-cloud-sdk/completion.zsh.inc' ]; then source '/Users/gherrera/dev/lib/google-cloud-sdk/completion.zsh.inc'; fi
+if [ -f "$HOME/dev/lib/google-cloud-sdk/completion.zsh.inc" ]; then source "$HOME/dev/lib/google-cloud-sdk/completion.zsh.inc"; fi


### PR DESCRIPTION
- profile: update servedir alias to Python 3 (http.server), remove EOL
  Python 2.7 PATH entry, conditionalize Conda PATH with existence check
- zshrc: replace hardcoded /Users/gherrera with $HOME in gcloud SDK paths
- eslintrc: remove trailing comma (JSON syntax error in env block)
- tmux.conf: add Ctrl-a prefix, pane splitting keybinds (|/-), config
  reload (r), new window in cwd, 256-color support, status bar
- README.md: expand from 8 lines to full setup guide with tool table,
  prerequisites, and installation instructions

https://claude.ai/code/session_018yimCp6wN3fEcQsTox1hKU